### PR TITLE
fix: log level detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${C
 
 set(${PROJECT_NAME}_MAJOR_VERSION 01)
 set(${PROJECT_NAME}_MINOR_VERSION 01)
-set(${PROJECT_NAME}_PATCH_VERSION 01)
+set(${PROJECT_NAME}_PATCH_VERSION 02)
 include(cmake/set_version_numbers.cmake)
 
 # Find the ControlSystemAdapter

--- a/src/Logging.cc
+++ b/src/Logging.cc
@@ -184,7 +184,7 @@ void LoggingModule::mainLoop() {
                              "when updating logging variables.");
     }
     try {
-      level = static_cast<LogLevel>(std::strtoul(&msg.at(0), NULL, 0));
+      level = static_cast<LogLevel>(std::strtoul(&msg.substr(0, 1).at(0), NULL, 0));
     }
     catch(std::out_of_range& e) {
       throw ctk::logic_error("Cannot find  message level"

--- a/tests/executable_src/testLogging.cc
+++ b/tests/executable_src/testLogging.cc
@@ -292,3 +292,30 @@ BOOST_AUTO_TEST_CASE(testLogging) {
   // should still be 4 because tailLength is 3!
   BOOST_CHECK_EQUAL(result.size(), 4);
 }
+
+BOOST_AUTO_TEST_CASE(testMessageWithNumber) {
+  testApp app;
+  ChimeraTK::TestFacility tf(app);
+
+  auto logLevel = tf.getScalar<uint>("/LoggingModule/logLevel");
+  auto tailLength = tf.getScalar<uint>("/LoggingModule/maxTailLength");
+
+  tf.runApplication();
+  logLevel = 0;
+  logLevel.write();
+  tailLength = 3;
+  tailLength.write();
+  app.dummy.logger->sendMessage("test message with number", LogLevel::DEBUG);
+  tf.stepApplication();
+  app.dummy.logger->sendMessage("4 test message with number", LogLevel::DEBUG);
+  tf.stepApplication();
+  app.dummy.logger->sendMessage("4test message with number", LogLevel::DEBUG);
+  tf.stepApplication();
+  auto tail = tf.readScalar<std::string>("/LoggingModule/logTail");
+  std::vector<std::string> result;
+  boost::algorithm::split(result, tail, boost::is_any_of("\n"));
+  BOOST_CHECK_EQUAL(result.size(), 4);
+  BOOST_CHECK_EQUAL(result.at(0).substr(result.at(0).find("->") + 3), std::string("test message with number"));
+  BOOST_CHECK_EQUAL(result.at(1).substr(result.at(1).find("->") + 3), std::string("4 test message with number"));
+  BOOST_CHECK_EQUAL(result.at(2).substr(result.at(2).find("->") + 3), std::string("4test message with number"));
+}


### PR DESCRIPTION
If the message was beginning with a number, the log level detection was not working because the level and the number number were interpreted together by strtoul.
